### PR TITLE
[17.0][FW] Blacklist of some PRs from 14.0

### DIFF
--- a/.oca/oca-port/blacklist/account_analytic_required.json
+++ b/.oca/oca-port/blacklist/account_analytic_required.json
@@ -1,0 +1,6 @@
+{
+  "pull_requests": {
+    "OCA/account-analytic#440": "Not needed anymore since 16.0 migration PR #541",
+    "OCA/account-analytic#442": "Not needed anymore since 16.0 migration PR #541"
+  }
+}


### PR DESCRIPTION
The following PRs have been blacklisted:
- `#440`: Not needed anymore since 16.0 migration PR `#541`
- `#442`: Not needed anymore since 16.0 migration PR `#541`